### PR TITLE
(chore) Allow more minor versions of Rubocop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,33 +1,33 @@
 PATH
   remote: .
   specs:
-    dxw-utils (0.1.0)
-      rubocop (~> 0.58.2)
-      rubocop-rspec (~> 1.29.1)
+    dxw-utils (0.1.1)
+      rubocop (~> 0.58)
+      rubocop-rspec (~> 1.29)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    jaro_winkler (1.5.1)
-    parallel (1.12.1)
-    parser (2.5.1.2)
+    jaro_winkler (1.5.2)
+    parallel (1.17.0)
+    parser (2.6.2.0)
       ast (~> 2.4.0)
-    powerpack (0.1.2)
+    psych (3.1.0)
     rainbow (3.0.0)
     rake (10.5.0)
-    rubocop (0.58.2)
+    rubocop (0.67.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
-      powerpack (~> 0.1)
+      psych (>= 3.1.0)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-rspec (1.29.1)
-      rubocop (>= 0.58.0)
+      unicode-display_width (>= 1.4.0, < 1.6)
+    rubocop-rspec (1.32.0)
+      rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
-    unicode-display_width (1.4.0)
+    unicode-display_width (1.5.0)
 
 PLATFORMS
   ruby

--- a/dxw-utils.gemspec
+++ b/dxw-utils.gemspec
@@ -35,6 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'rake', '~> 10.0'
 
-  spec.add_dependency 'rubocop', '~> 0.58.2'
-  spec.add_dependency 'rubocop-rspec', '~> 1.29.1'
+  spec.add_dependency 'rubocop', '~> 0.58'
+  spec.add_dependency 'rubocop-rspec', '~> 1.29'
 end

--- a/lib/dxw/utils/version.rb
+++ b/lib/dxw/utils/version.rb
@@ -2,6 +2,6 @@
 
 module Dxw
   module Utils
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end


### PR DESCRIPTION
We're using `dxw-utils` on a new project (Teacher’s Payment Service)

When installing it, we got a dependency conflict because we had the
latest version of Rubocop installed (0.66.0) and there's a dependency in
`dxw-utils` for ~> 0.58.2 which I think is equivalent to:
`>= 0.58.2` and `< 0.59`

By leaving the patch version off the dependency we allow any minor
version < 1.0